### PR TITLE
Normalize message IDs

### DIFF
--- a/locales/en-US/index.json
+++ b/locales/en-US/index.json
@@ -1,33 +1,33 @@
 {
-  "auth.sign-in.button.sign-in": {
-    "message": "Sign in"
-  },
-  "auth.sign-in.input.two-factor-code.placeholder": {
-    "message": "Enter code..."
-  },
-  "auth.sign-in.label.additional-options": {
-    "message": "<forgot-password-link>Forgot password?</forgot-password-link> • <create-account-link>Create an account</create-account-link>"
-  },
-  "auth.sign-in.label.email-username": {
-    "message": "Email or username"
-  },
-  "auth.sign-in.label.password": {
-    "message": "Password"
-  },
-  "auth.sign-in.label.sign-in-with": {
-    "message": "Sign in with"
-  },
-  "auth.sign-in.label.two-factor-code": {
-    "message": "Enter two-factor code"
-  },
-  "auth.sign-in.label.two-factor-code.description": {
+  "auth.sign-in.2fa.description": {
     "message": "Please enter a two-factor code to proceed."
   },
-  "auth.sign-in.label.use-password": {
-    "message": "Or use a password"
+  "auth.sign-in.2fa.label": {
+    "message": "Enter two-factor code"
+  },
+  "auth.sign-in.2fa.placeholder": {
+    "message": "Enter code..."
+  },
+  "auth.sign-in.action.sign-in": {
+    "message": "Sign in"
+  },
+  "auth.sign-in.additional-options": {
+    "message": "<forgot-password-link>Forgot password?</forgot-password-link> • <create-account-link>Create an account</create-account-link>"
+  },
+  "auth.sign-in.email-username.label": {
+    "message": "Email or username"
+  },
+  "auth.sign-in.password.label": {
+    "message": "Password"
+  },
+  "auth.sign-in.sign-in-with": {
+    "message": "Sign in with"
   },
   "auth.sign-in.title": {
     "message": "Sign In"
+  },
+  "auth.sign-in.use-password": {
+    "message": "Or use a password"
   },
   "auth.welcome.checkbox.subscribe": {
     "message": "Subscribe to updates about Modrinth"

--- a/pages/auth/sign-in.vue
+++ b/pages/auth/sign-in.vue
@@ -121,24 +121,24 @@ const { formatMessage } = useVIntl()
 
 const messages = defineMessages({
   additionalOptionsLabel: {
-    id: 'auth.sign-in.label.additional-options',
+    id: 'auth.sign-in.additional-options',
     defaultMessage:
       '<forgot-password-link>Forgot password?</forgot-password-link> • <create-account-link>Create an account</create-account-link>',
   },
   emailUsernameLabel: {
-    id: 'auth.sign-in.label.email-username',
+    id: 'auth.sign-in.email-username.label',
     defaultMessage: 'Email or username',
   },
   passwordLabel: {
-    id: 'auth.sign-in.label.password',
+    id: 'auth.sign-in.password.label',
     defaultMessage: 'Password',
   },
   signInButton: {
-    id: 'auth.sign-in.button.sign-in',
+    id: 'auth.sign-in.action.sign-in',
     defaultMessage: 'Sign in',
   },
   signInWithLabel: {
-    id: 'auth.sign-in.label.sign-in-with',
+    id: 'auth.sign-in.sign-in-with',
     defaultMessage: 'Sign in with',
   },
   signInTitle: {
@@ -146,19 +146,19 @@ const messages = defineMessages({
     defaultMessage: 'Sign In',
   },
   twoFactorCodeInputPlaceholder: {
-    id: 'auth.sign-in.input.two-factor-code.placeholder',
+    id: 'auth.sign-in.2fa.placeholder',
     defaultMessage: 'Enter code...',
   },
   twoFactorCodeLabel: {
-    id: 'auth.sign-in.label.two-factor-code',
+    id: 'auth.sign-in.2fa.label',
     defaultMessage: 'Enter two-factor code',
   },
   twoFactorCodeLabelDescription: {
-    id: 'auth.sign-in.label.two-factor-code.description',
+    id: 'auth.sign-in.2fa.description',
     defaultMessage: 'Please enter a two-factor code to proceed.',
   },
   usePasswordLabel: {
-    id: 'auth.sign-in.label.use-password',
+    id: 'auth.sign-in.use-password',
     defaultMessage: 'Or use a password',
   },
 })


### PR DESCRIPTION
It makes sense to compose message IDs in order:
- Place (page, sub page / "modal")
- Thing
- (optionally) Relation to the thing

For example, a label for a password field would be:
- auth.sign-in (on sign-in subpage of auth)
- password (password field)
- label (is a label for the field)

Another example - button to sign in:
- auth.sign-in
- action (this is an action to do something)
- sign-in (action to sign in)

This helps keep the IDs closer to the actual structure of the page,
oftentimes smaller in the code, and easier to understand by translators.
